### PR TITLE
Enforce apps service authorization

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -525,11 +525,17 @@ func (s *Server) ListInstallations(ctx context.Context, req *appsv1.ListInstalla
 		return nil, status.Errorf(codes.Internal, "list installations: %v", err)
 	}
 	protoInstallations := make([]*appsv1.Installation, 0, len(installations))
+	orgAccess := map[uuid.UUID]bool{}
 	for _, installation := range installations {
 		if filter.OrganizationID == nil {
-			allowed, err := s.orgRelationAllowed(ctx, callerID, installation.OrganizationID, "member")
-			if err != nil {
-				return nil, err
+			allowed, ok := orgAccess[installation.OrganizationID]
+			if !ok {
+				var err error
+				allowed, err = s.orgRelationAllowed(ctx, callerID, installation.OrganizationID, "member")
+				if err != nil {
+					return nil, err
+				}
+				orgAccess[installation.OrganizationID] = allowed
 			}
 			if !allowed {
 				continue

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -21,15 +21,13 @@ import (
 )
 
 const (
-	clusterObject            = "cluster:global"
-	clusterAppWriterRelation = "writer"
-	identityMetadata         = "x-identity-id"
+	identityMetadata = "x-identity-id"
 )
 
 var permissionToRelation = map[string]string{
-	"thread:create":   "can_create_thread",
-	"thread:write":    "can_write_thread",
-	"participant:add": "can_add_participant",
+	"thread:create":   "thread_create",
+	"thread:write":    "thread_write",
+	"participant:add": "participant_add",
 }
 
 type AppStore interface {
@@ -117,18 +115,11 @@ func (s *Server) CreateApp(ctx context.Context, req *appsv1.CreateAppRequest) (*
 		return nil, status.Errorf(codes.Internal, "register identity: %v", err)
 	}
 
-	if err := s.writeAppAuthorization(ctx, identityID); err != nil {
-		// TODO: clean up orphaned identity once Identity service supports deletion.
-		log.Printf("WARN: orphaned identity %s after authorization failure", identityID)
-		return nil, err
-	}
-
 	zitiServiceResp, err := s.zitiManagementClient.CreateService(ctx, &zitimanagementv1.CreateServiceRequest{
 		Name:           fmt.Sprintf("app-%s", slug),
 		RoleAttributes: []string{"app-services"},
 	})
 	if err != nil {
-		s.cleanupAuthorization(ctx, identityID)
 		return nil, status.Errorf(codes.Internal, "create ziti service: %v", err)
 	}
 
@@ -148,7 +139,6 @@ func (s *Server) CreateApp(ctx context.Context, req *appsv1.CreateAppRequest) (*
 	})
 	if err != nil {
 		s.cleanupZitiIdentity(ctx, identityID, zitiServiceResp.GetZitiServiceId())
-		s.cleanupAuthorization(ctx, identityID)
 		// TODO: clean up orphaned identity once Identity service supports deletion.
 		log.Printf("WARN: orphaned identity %s after store failure", identityID)
 		return nil, toStatusError(err)
@@ -206,6 +196,10 @@ func (s *Server) UpdateApp(ctx context.Context, req *appsv1.UpdateAppRequest) (*
 }
 
 func (s *Server) GetApp(ctx context.Context, req *appsv1.GetAppRequest) (*appsv1.GetAppResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -214,10 +208,19 @@ func (s *Server) GetApp(ctx context.Context, req *appsv1.GetAppRequest) (*appsv1
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if app.Visibility == store.AppVisibilityInternal {
+		if err := s.requireOrgMember(ctx, callerID, app.OrganizationID); err != nil {
+			return nil, err
+		}
+	}
 	return &appsv1.GetAppResponse{App: toProtoApp(app)}, nil
 }
 
 func (s *Server) GetAppBySlug(ctx context.Context, req *appsv1.GetAppBySlugRequest) (*appsv1.GetAppBySlugResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
@@ -230,15 +233,27 @@ func (s *Server) GetAppBySlug(ctx context.Context, req *appsv1.GetAppBySlugReque
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if app.Visibility == store.AppVisibilityInternal {
+		if err := s.requireOrgMember(ctx, callerID, app.OrganizationID); err != nil {
+			return nil, err
+		}
+	}
 	return &appsv1.GetAppBySlugResponse{App: toProtoApp(app)}, nil
 }
 
 func (s *Server) ListApps(ctx context.Context, req *appsv1.ListAppsRequest) (*appsv1.ListAppsResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	filter := store.ListAppsFilter{}
 	if req.GetOrganizationId() != "" {
 		organizationID, err := parseUUID(req.GetOrganizationId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		if err := s.requireOrgMember(ctx, callerID, organizationID); err != nil {
+			return nil, err
 		}
 		filter.OrganizationID = &organizationID
 	}
@@ -248,6 +263,14 @@ func (s *Server) ListApps(ctx context.Context, req *appsv1.ListAppsRequest) (*ap
 			return nil, status.Errorf(codes.InvalidArgument, "visibility: %v", err)
 		}
 		filter.Visibility = &visibility
+	}
+	if filter.OrganizationID == nil {
+		if filter.Visibility == nil {
+			visibility := store.AppVisibilityPublic
+			filter.Visibility = &visibility
+		} else if *filter.Visibility != store.AppVisibilityPublic {
+			return nil, status.Error(codes.PermissionDenied, "permission denied")
+		}
 	}
 
 	apps, nextToken, err := s.store.ListApps(ctx, int(req.GetPageSize()), req.GetPageToken(), filter)
@@ -294,7 +317,6 @@ func (s *Server) DeleteApp(ctx context.Context, req *appsv1.DeleteAppRequest) (*
 			return nil, status.Errorf(codes.Internal, "delete ziti identity: %v", err)
 		}
 	}
-	s.cleanupAuthorization(ctx, app.IdentityID)
 
 	if err := s.store.DeleteApp(ctx, id); err != nil {
 		return nil, toStatusError(err)
@@ -303,6 +325,9 @@ func (s *Server) DeleteApp(ctx context.Context, req *appsv1.DeleteAppRequest) (*
 }
 
 func (s *Server) GetAppProfile(ctx context.Context, req *appsv1.GetAppProfileRequest) (*appsv1.GetAppProfileResponse, error) {
+	if _, err := identityFromMetadata(ctx); err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	identityID, err := parseUUID(req.GetIdentityId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "identity_id: %v", err)
@@ -418,6 +443,10 @@ func (s *Server) InstallApp(ctx context.Context, req *appsv1.InstallAppRequest) 
 }
 
 func (s *Server) GetInstallation(ctx context.Context, req *appsv1.GetInstallationRequest) (*appsv1.GetInstallationResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	id, err := parseUUID(req.GetId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "id: %v", err)
@@ -425,6 +454,9 @@ func (s *Server) GetInstallation(ctx context.Context, req *appsv1.GetInstallatio
 	installation, err := s.store.GetInstallation(ctx, id)
 	if err != nil {
 		return nil, toStatusError(err)
+	}
+	if err := s.requireOrgMember(ctx, callerID, installation.OrganizationID); err != nil {
+		return nil, err
 	}
 	protoInstallation, err := toProtoInstallation(installation)
 	if err != nil {
@@ -434,6 +466,10 @@ func (s *Server) GetInstallation(ctx context.Context, req *appsv1.GetInstallatio
 }
 
 func (s *Server) GetInstallationBySlug(ctx context.Context, req *appsv1.GetInstallationBySlugRequest) (*appsv1.GetInstallationBySlugResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	organizationID, err := parseUUID(req.GetOrganizationId())
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
@@ -446,6 +482,9 @@ func (s *Server) GetInstallationBySlug(ctx context.Context, req *appsv1.GetInsta
 	if err != nil {
 		return nil, toStatusError(err)
 	}
+	if err := s.requireOrgMember(ctx, callerID, installation.OrganizationID); err != nil {
+		return nil, err
+	}
 	protoInstallation, err := toProtoInstallation(installation)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "convert installation: %v", err)
@@ -454,11 +493,18 @@ func (s *Server) GetInstallationBySlug(ctx context.Context, req *appsv1.GetInsta
 }
 
 func (s *Server) ListInstallations(ctx context.Context, req *appsv1.ListInstallationsRequest) (*appsv1.ListInstallationsResponse, error) {
+	callerID, err := identityFromMetadata(ctx)
+	if err != nil {
+		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
+	}
 	filter := store.ListInstallationsFilter{}
 	if req.GetOrganizationId() != "" {
 		organizationID, err := parseUUID(req.GetOrganizationId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		if err := s.requireOrgMember(ctx, callerID, organizationID); err != nil {
+			return nil, err
 		}
 		filter.OrganizationID = &organizationID
 	}
@@ -480,6 +526,15 @@ func (s *Server) ListInstallations(ctx context.Context, req *appsv1.ListInstalla
 	}
 	protoInstallations := make([]*appsv1.Installation, 0, len(installations))
 	for _, installation := range installations {
+		if filter.OrganizationID == nil {
+			allowed, err := s.orgRelationAllowed(ctx, callerID, installation.OrganizationID, "member")
+			if err != nil {
+				return nil, err
+			}
+			if !allowed {
+				continue
+			}
+		}
 		protoInstallation, err := toProtoInstallation(installation)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "convert installation: %v", err)
@@ -585,36 +640,39 @@ func (s *Server) GetInstallationConfiguration(ctx context.Context, req *appsv1.G
 }
 
 func (s *Server) requireOrgOwner(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
-	resp, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
-		TupleKey: &authorizationv1.TupleKey{
-			User:     fmt.Sprintf("identity:%s", identityID.String()),
-			Relation: "owner",
-			Object:   fmt.Sprintf("organization:%s", organizationID.String()),
-		},
-	})
+	allowed, err := s.orgRelationAllowed(ctx, identityID, organizationID, "owner")
 	if err != nil {
-		return status.Errorf(codes.Internal, "authorization check: %v", err)
+		return err
 	}
-	if !resp.GetAllowed() {
+	if !allowed {
 		return status.Error(codes.PermissionDenied, "permission denied")
 	}
 	return nil
 }
 
-func (s *Server) writeAppAuthorization(ctx context.Context, identityID uuid.UUID) error {
-	_, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
-		Writes: []*authorizationv1.TupleKey{
-			{
-				User:     fmt.Sprintf("identity:%s", identityID.String()),
-				Relation: clusterAppWriterRelation,
-				Object:   clusterObject,
-			},
+func (s *Server) requireOrgMember(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID) error {
+	allowed, err := s.orgRelationAllowed(ctx, identityID, organizationID, "member")
+	if err != nil {
+		return err
+	}
+	if !allowed {
+		return status.Error(codes.PermissionDenied, "permission denied")
+	}
+	return nil
+}
+
+func (s *Server) orgRelationAllowed(ctx context.Context, identityID uuid.UUID, organizationID uuid.UUID, relation string) (bool, error) {
+	resp, err := s.authorizationClient.Check(ctx, &authorizationv1.CheckRequest{
+		TupleKey: &authorizationv1.TupleKey{
+			User:     fmt.Sprintf("identity:%s", identityID.String()),
+			Relation: relation,
+			Object:   fmt.Sprintf("organization:%s", organizationID.String()),
 		},
 	})
 	if err != nil {
-		return status.Errorf(codes.Internal, "authorization write: %v", err)
+		return false, status.Errorf(codes.Internal, "authorization check: %v", err)
 	}
-	return nil
+	return resp.GetAllowed(), nil
 }
 
 func (s *Server) writeInstallationTuples(ctx context.Context, app store.App, organizationID uuid.UUID) error {
@@ -661,20 +719,6 @@ func (s *Server) deleteInstallationTuples(ctx context.Context, app store.App, or
 	}
 	if _, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{Deletes: tuples}); err != nil {
 		log.Printf("WARN: best-effort cleanup of installation tuples for org %s failed: %v", organizationID, err)
-	}
-}
-
-func (s *Server) cleanupAuthorization(ctx context.Context, identityID uuid.UUID) {
-	if _, err := s.authorizationClient.Write(ctx, &authorizationv1.WriteRequest{
-		Deletes: []*authorizationv1.TupleKey{
-			{
-				User:     fmt.Sprintf("identity:%s", identityID.String()),
-				Relation: clusterAppWriterRelation,
-				Object:   clusterObject,
-			},
-		},
-	}); err != nil {
-		log.Printf("WARN: best-effort cleanup of authz tuple for identity %s failed: %v", identityID, err)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -427,8 +427,8 @@ func TestCreateAppSuccess(t *testing.T) {
 	if identityClient.registerRequests[0].IdentityType != identityv1.IdentityType_IDENTITY_TYPE_APP {
 		t.Fatalf("expected identity type app")
 	}
-	if len(authorizationClient.writeRequests) != 1 || len(authorizationClient.writeRequests[0].Writes) != 1 {
-		t.Fatalf("expected authorization write")
+	if len(authorizationClient.writeRequests) != 0 {
+		t.Fatalf("did not expect authorization writes")
 	}
 	if len(zitiClient.createServiceRequests) != 1 {
 		t.Fatalf("expected ziti service create")
@@ -444,45 +444,6 @@ func TestCreateAppSuccess(t *testing.T) {
 	}
 	if len(zitiClient.deleteRequests) != 0 {
 		t.Fatalf("did not expect ziti delete")
-	}
-}
-
-func TestCreateAppRollbackOnAuthzWriteError(t *testing.T) {
-	ctx, _ := newAdminContext()
-	identityClient := &fakeIdentityClient{}
-	authorizationClient := &fakeAuthorizationClient{}
-	authorizationClient.writeFn = func(_ context.Context, _ *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
-		return nil, status.Error(codes.Internal, "authz down")
-	}
-	zitiClient := &fakeZitiManagementClient{}
-	store := &fakeStore{}
-	organizationID := uuid.New()
-
-	srv := New(store, identityClient, authorizationClient, zitiClient)
-	_, err := srv.CreateApp(ctx, &appsv1.CreateAppRequest{
-		OrganizationId: organizationID.String(),
-		Slug:           "demo",
-		Name:           "Demo",
-		Visibility:     appsv1.AppVisibility_APP_VISIBILITY_INTERNAL,
-		Permissions:    []string{"thread:create"},
-	})
-	if status.Code(err) != codes.Internal {
-		t.Fatalf("expected internal error, got %v", status.Code(err))
-	}
-	if len(identityClient.registerRequests) != 1 {
-		t.Fatalf("expected identity registration before authz failure")
-	}
-	if len(zitiClient.createServiceRequests) != 0 {
-		t.Fatalf("did not expect ziti service create")
-	}
-	if len(zitiClient.createRequests) != 0 {
-		t.Fatalf("did not expect ziti create")
-	}
-	if len(zitiClient.deleteRequests) != 0 {
-		t.Fatalf("did not expect ziti cleanup")
-	}
-	if len(store.createInputs) != 0 {
-		t.Fatalf("did not expect store create")
 	}
 }
 
@@ -511,11 +472,8 @@ func TestCreateAppRollbackOnStoreError(t *testing.T) {
 	if status.Code(err) != codes.AlreadyExists {
 		t.Fatalf("expected already exists, got %v", status.Code(err))
 	}
-	if len(authorizationClient.writeRequests) != 2 {
-		t.Fatalf("expected authz cleanup")
-	}
-	if len(authorizationClient.writeRequests[1].Deletes) != 1 {
-		t.Fatalf("expected authz delete in cleanup")
+	if len(authorizationClient.writeRequests) != 0 {
+		t.Fatalf("did not expect authorization writes")
 	}
 	if len(identityClient.registerRequests) != 1 {
 		t.Fatalf("expected identity registration before store failure")
@@ -572,9 +530,6 @@ func TestDeleteApp(t *testing.T) {
 	}
 	if zitiClient.deleteRequests[0].GetZitiServiceId() != "ziti-service" {
 		t.Fatalf("expected ziti service id cleanup")
-	}
-	if len(authorizationClient.writeRequests) != 1 || len(authorizationClient.writeRequests[0].Deletes) != 1 {
-		t.Fatalf("expected authz delete")
 	}
 	if len(store.deleteCalls) != 1 {
 		t.Fatalf("expected store delete")
@@ -660,9 +615,6 @@ func TestDeleteAppAllowsMissingZitiIdentity(t *testing.T) {
 	}
 	if len(store.deleteCalls) != 1 {
 		t.Fatalf("expected store delete")
-	}
-	if len(authorizationClient.writeRequests) != 1 {
-		t.Fatalf("expected authz cleanup")
 	}
 }
 
@@ -970,6 +922,220 @@ func TestUpdateAppSuccess(t *testing.T) {
 	}
 }
 
+func TestGetAppPublicSkipsMemberCheck(t *testing.T) {
+	ctx, _ := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	store.getFn = func(_ context.Context, _ uuid.UUID) (storepkg.App, error) {
+		return storepkg.App{
+			Meta:           storepkg.EntityMeta{ID: appID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			Slug:           "public",
+			Name:           "Public",
+			OrganizationID: uuid.New(),
+			Visibility:     storepkg.AppVisibilityPublic,
+			IdentityID:     uuid.New(),
+		}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetApp(ctx, &appsv1.GetAppRequest{Id: appID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 0 {
+		t.Fatalf("did not expect authorization checks")
+	}
+}
+
+func TestGetAppInternalRequiresMember(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	organizationID := uuid.New()
+	store.getFn = func(_ context.Context, _ uuid.UUID) (storepkg.App, error) {
+		return storepkg.App{
+			Meta:           storepkg.EntityMeta{ID: appID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			Slug:           "internal",
+			Name:           "Internal",
+			OrganizationID: organizationID,
+			Visibility:     storepkg.AppVisibilityInternal,
+			IdentityID:     uuid.New(),
+		}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetApp(ctx, &appsv1.GetAppRequest{Id: appID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
+func TestGetAppBySlugInternalRequiresMember(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	organizationID := uuid.New()
+	store.getBySlugFn = func(_ context.Context, _ uuid.UUID, _ string) (storepkg.App, error) {
+		return storepkg.App{
+			Meta:           storepkg.EntityMeta{ID: appID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			Slug:           "internal",
+			Name:           "Internal",
+			OrganizationID: organizationID,
+			Visibility:     storepkg.AppVisibilityInternal,
+			IdentityID:     uuid.New(),
+		}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetAppBySlug(ctx, &appsv1.GetAppBySlugRequest{OrganizationId: organizationID.String(), Slug: "internal"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
+func TestGetAppProfileRequiresAuth(t *testing.T) {
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetAppProfile(context.Background(), &appsv1.GetAppProfileRequest{IdentityId: uuid.New().String()})
+	if status.Code(err) != codes.Unauthenticated {
+		t.Fatalf("expected unauthenticated, got %v", status.Code(err))
+	}
+}
+
+func TestListAppsDefaultsToPublic(t *testing.T) {
+	ctx, _ := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	store.listFn = func(_ context.Context, _ int, _ string, filter storepkg.ListAppsFilter) ([]storepkg.App, string, error) {
+		if filter.OrganizationID != nil {
+			return nil, "", errors.New("expected no org filter")
+		}
+		if filter.Visibility == nil || *filter.Visibility != storepkg.AppVisibilityPublic {
+			return nil, "", errors.New("expected public visibility")
+		}
+		return []storepkg.App{}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	resp, err := srv.ListApps(ctx, &appsv1.ListAppsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetApps()) != 0 {
+		t.Fatalf("expected no apps")
+	}
+	if len(authorizationClient.checkRequests) != 0 {
+		t.Fatalf("did not expect authorization checks")
+	}
+}
+
+func TestListAppsRejectsInternalWithoutOrg(t *testing.T) {
+	ctx, _ := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+	called := false
+
+	store.listFn = func(_ context.Context, _ int, _ string, _ storepkg.ListAppsFilter) ([]storepkg.App, string, error) {
+		called = true
+		return []storepkg.App{}, "", nil
+	}
+
+	visibility := appsv1.AppVisibility_APP_VISIBILITY_INTERNAL
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.ListApps(ctx, &appsv1.ListAppsRequest{Visibility: visibility})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", status.Code(err))
+	}
+	if called {
+		t.Fatalf("did not expect store list")
+	}
+}
+
+func TestListAppsRequiresMemberForOrgFilter(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	organizationID := uuid.New()
+	store.listFn = func(_ context.Context, _ int, _ string, filter storepkg.ListAppsFilter) ([]storepkg.App, string, error) {
+		if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+			return nil, "", errors.New("expected org filter")
+		}
+		if filter.Visibility != nil {
+			return nil, "", errors.New("expected no visibility filter")
+		}
+		return []storepkg.App{}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.ListApps(ctx, &appsv1.ListAppsRequest{OrganizationId: organizationID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
 func TestUpdateInstallationSuccess(t *testing.T) {
 	ctx, _ := newAdminContext()
 	identityClient := &fakeIdentityClient{}
@@ -1026,6 +1192,173 @@ func TestUpdateInstallationSuccess(t *testing.T) {
 	}
 	if resp.GetInstallation().GetConfiguration().AsMap()["region"] != "us-east" {
 		t.Fatalf("expected response configuration")
+	}
+}
+
+func TestGetInstallationRequiresMember(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	store.getInstallationFn = func(_ context.Context, _ uuid.UUID) (storepkg.Installation, error) {
+		return storepkg.Installation{
+			Meta:           storepkg.EntityMeta{ID: installationID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			AppID:          uuid.New(),
+			OrganizationID: organizationID,
+			Slug:           "install",
+		}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetInstallation(ctx, &appsv1.GetInstallationRequest{Id: installationID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
+func TestGetInstallationBySlugRequiresMember(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	store.getInstallationBySlugFn = func(_ context.Context, _ uuid.UUID, _ string) (storepkg.Installation, error) {
+		return storepkg.Installation{
+			Meta:           storepkg.EntityMeta{ID: installationID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			AppID:          uuid.New(),
+			OrganizationID: organizationID,
+			Slug:           "install",
+		}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetInstallationBySlug(ctx, &appsv1.GetInstallationBySlugRequest{OrganizationId: organizationID.String(), Slug: "install"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
+func TestListInstallationsRequiresMemberForOrgFilter(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	organizationID := uuid.New()
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, filter storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		if filter.OrganizationID == nil || *filter.OrganizationID != organizationID {
+			return nil, "", errors.New("expected org filter")
+		}
+		return []storepkg.Installation{}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{OrganizationId: organizationID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
+	}
+}
+
+func TestListInstallationsFiltersByMembership(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	allowedOrg := uuid.New()
+	blockedOrg := uuid.New()
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, _ storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		return []storepkg.Installation{
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				AppID:          uuid.New(),
+				OrganizationID: allowedOrg,
+				Slug:           "allowed",
+			},
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				AppID:          uuid.New(),
+				OrganizationID: blockedOrg,
+				Slug:           "blocked",
+			},
+		}, "", nil
+	}
+	authorizationClient.checkFn = func(_ context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		if req.GetTupleKey().GetObject() == fmt.Sprintf("organization:%s", allowedOrg) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		}
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	resp, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetInstallations()) != 1 {
+		t.Fatalf("expected one authorized installation")
+	}
+	if resp.GetInstallations()[0].GetOrganizationId() != allowedOrg.String() {
+		t.Fatalf("expected installation for org %s", allowedOrg)
+	}
+	if len(authorizationClient.checkRequests) != 2 {
+		t.Fatalf("expected membership checks for both orgs")
+	}
+	for _, check := range authorizationClient.checkRequests {
+		if check.GetTupleKey().GetRelation() != "member" {
+			t.Fatalf("expected member relation")
+		}
+		if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+			t.Fatalf("expected user to be %s", callerID)
+		}
 	}
 }
 
@@ -1107,6 +1440,67 @@ func TestInstallAppDefaultsSlug(t *testing.T) {
 	}
 	if resp.GetInstallation().GetSlug() != "demo" {
 		t.Fatalf("expected response slug to be defaulted")
+	}
+}
+
+func TestInstallAppWritesPermissionTuples(t *testing.T) {
+	ctx, _ := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	organizationID := uuid.New()
+	appIdentityID := uuid.New()
+	store.getFn = func(_ context.Context, _ uuid.UUID) (storepkg.App, error) {
+		return storepkg.App{
+			Meta:           storepkg.EntityMeta{ID: appID},
+			Slug:           "demo",
+			OrganizationID: organizationID,
+			Visibility:     storepkg.AppVisibilityInternal,
+			IdentityID:     appIdentityID,
+			Permissions:    []string{"thread:create", "thread:write", "participant:add"},
+		}, nil
+	}
+	store.createInstallationFn = func(_ context.Context, input storepkg.CreateInstallationInput) (storepkg.Installation, error) {
+		return storepkg.Installation{
+			Meta:           storepkg.EntityMeta{ID: input.ID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			AppID:          input.AppID,
+			OrganizationID: input.OrganizationID,
+			Slug:           input.Slug,
+			Configuration:  input.Configuration,
+		}, nil
+	}
+	authorizationClient.writeFn = func(_ context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
+		if len(req.Writes) != 3 {
+			return nil, errors.New("expected three permission tuples")
+		}
+		relations := map[string]bool{}
+		for _, tuple := range req.Writes {
+			if tuple.GetUser() != fmt.Sprintf("identity:%s", appIdentityID) {
+				return nil, fmt.Errorf("unexpected user %s", tuple.GetUser())
+			}
+			if tuple.GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+				return nil, fmt.Errorf("unexpected object %s", tuple.GetObject())
+			}
+			relations[tuple.GetRelation()] = true
+		}
+		for _, relation := range []string{"thread_create", "thread_write", "participant_add"} {
+			if !relations[relation] {
+				return nil, fmt.Errorf("missing relation %s", relation)
+			}
+		}
+		return &authorizationv1.WriteResponse{}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.InstallApp(ctx, &appsv1.InstallAppRequest{AppId: appID.String(), OrganizationId: organizationID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(authorizationClient.writeRequests) != 1 {
+		t.Fatalf("expected permission tuples to be written")
 	}
 }
 
@@ -1199,6 +1593,9 @@ func TestUninstallAppDeletesTuplesBeforeStore(t *testing.T) {
 	authorizationClient.writeFn = func(_ context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error) {
 		if len(req.Deletes) != 1 {
 			return nil, errors.New("expected delete tuples")
+		}
+		if req.Deletes[0].GetRelation() != "thread_create" {
+			return nil, errors.New("expected thread_create relation")
 		}
 		order = append(order, "auth")
 		return &authorizationv1.WriteResponse{}, nil

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1233,6 +1233,37 @@ func TestGetInstallationRequiresMember(t *testing.T) {
 	}
 }
 
+func TestGetInstallationRejectsNonMember(t *testing.T) {
+	ctx, _ := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	installationID := uuid.New()
+	organizationID := uuid.New()
+	store.getInstallationFn = func(_ context.Context, _ uuid.UUID) (storepkg.Installation, error) {
+		return storepkg.Installation{
+			Meta:           storepkg.EntityMeta{ID: installationID, CreatedAt: time.Now(), UpdatedAt: time.Now()},
+			AppID:          uuid.New(),
+			OrganizationID: organizationID,
+			Slug:           "install",
+		}, nil
+	}
+	authorizationClient.checkFn = func(_ context.Context, _ *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.GetInstallation(ctx, &appsv1.GetInstallationRequest{Id: installationID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", status.Code(err))
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected member check")
+	}
+}
+
 func TestGetInstallationBySlugRequiresMember(t *testing.T) {
 	ctx, callerID := newAdminContext()
 	identityClient := &fakeIdentityClient{}
@@ -1359,6 +1390,54 @@ func TestListInstallationsFiltersByMembership(t *testing.T) {
 		if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
 			t.Fatalf("expected user to be %s", callerID)
 		}
+	}
+}
+
+func TestListInstallationsCachesMembershipChecks(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	organizationID := uuid.New()
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, _ storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		return []storepkg.Installation{
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				AppID:          uuid.New(),
+				OrganizationID: organizationID,
+				Slug:           "one",
+			},
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: time.Now(), UpdatedAt: time.Now()},
+				AppID:          uuid.New(),
+				OrganizationID: organizationID,
+				Slug:           "two",
+			},
+		}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	resp, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetInstallations()) != 2 {
+		t.Fatalf("expected two installations")
+	}
+	if len(authorizationClient.checkRequests) != 1 {
+		t.Fatalf("expected one membership check")
+	}
+	check := authorizationClient.checkRequests[0]
+	if check.GetTupleKey().GetRelation() != "member" {
+		t.Fatalf("expected member relation")
+	}
+	if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+		t.Fatalf("expected user to be %s", callerID)
+	}
+	if check.GetTupleKey().GetObject() != fmt.Sprintf("organization:%s", organizationID) {
+		t.Fatalf("expected org check for %s", organizationID)
 	}
 }
 


### PR DESCRIPTION
## Summary
- enforce read/list authorization checks for apps and installations
- update installation tuple relations to thread_* permissions without cluster writer
- expand server tests for new authorization behavior and tuple mapping

## Testing
- buf generate --template buf.gen.yaml
- go vet ./...
- go test ./...

Ref: #136