### PR TITLE
Allow app identity to list installations

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -502,22 +502,37 @@ func (s *Server) ListInstallations(ctx context.Context, req *appsv1.ListInstalla
 		return nil, status.Errorf(codes.Unauthenticated, "unauthenticated: %v", err)
 	}
 	filter := store.ListInstallationsFilter{}
-	if req.GetOrganizationId() != "" {
-		organizationID, err := parseUUID(req.GetOrganizationId())
-		if err != nil {
-			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
-		}
-		if err := s.requireOrgMember(ctx, callerID, organizationID); err != nil {
-			return nil, err
-		}
-		filter.OrganizationID = &organizationID
-	}
+	allowAppIdentity := false
 	if req.GetAppId() != "" {
 		appID, err := parseUUID(req.GetAppId())
 		if err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "app_id: %v", err)
 		}
 		filter.AppID = &appID
+		app, err := s.store.GetAppByIdentityID(ctx, callerID)
+		if err != nil {
+			var notFound *store.NotFoundError
+			if !errors.As(err, &notFound) {
+				return nil, toStatusError(err)
+			}
+		} else {
+			if app.Meta.ID != appID {
+				return nil, status.Error(codes.PermissionDenied, "permission denied")
+			}
+			allowAppIdentity = true
+		}
+	}
+	if req.GetOrganizationId() != "" {
+		organizationID, err := parseUUID(req.GetOrganizationId())
+		if err != nil {
+			return nil, status.Errorf(codes.InvalidArgument, "organization_id: %v", err)
+		}
+		if !allowAppIdentity {
+			if err := s.requireOrgMember(ctx, callerID, organizationID); err != nil {
+				return nil, err
+			}
+		}
+		filter.OrganizationID = &organizationID
 	}
 
 	installations, nextToken, err := s.store.ListInstallations(ctx, int(req.GetPageSize()), req.GetPageToken(), filter)
@@ -531,7 +546,7 @@ func (s *Server) ListInstallations(ctx context.Context, req *appsv1.ListInstalla
 	protoInstallations := make([]*appsv1.Installation, 0, len(installations))
 	orgAccess := map[uuid.UUID]bool{}
 	for _, installation := range installations {
-		if filter.OrganizationID == nil {
+		if filter.OrganizationID == nil && !allowAppIdentity {
 			allowed, ok := orgAccess[installation.OrganizationID]
 			if !ok {
 				var err error

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1456,6 +1456,151 @@ func TestListInstallationsRequiresMemberForOrgFilter(t *testing.T) {
 	}
 }
 
+func TestListInstallationsAllowsAppIdentityWithAppID(t *testing.T) {
+	identityID := uuid.New()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, identityID.String()))
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	store.getByIdentityFn = func(_ context.Context, id uuid.UUID) (storepkg.App, error) {
+		if id != identityID {
+			return storepkg.App{}, fmt.Errorf("unexpected identity id")
+		}
+		return storepkg.App{Meta: storepkg.EntityMeta{ID: appID}, IdentityID: identityID}, nil
+	}
+
+	orgOne := uuid.New()
+	orgTwo := uuid.New()
+	now := time.Now()
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, filter storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		if filter.AppID == nil || *filter.AppID != appID {
+			return nil, "", errors.New("expected app filter")
+		}
+		return []storepkg.Installation{
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: now, UpdatedAt: now},
+				AppID:          appID,
+				OrganizationID: orgOne,
+				Slug:           "one",
+			},
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: now, UpdatedAt: now},
+				AppID:          appID,
+				OrganizationID: orgTwo,
+				Slug:           "two",
+			},
+		}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	resp, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{AppId: appID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetInstallations()) != 2 {
+		t.Fatalf("expected two installations")
+	}
+	if len(authorizationClient.checkRequests) != 0 {
+		t.Fatalf("expected no member checks")
+	}
+}
+
+func TestListInstallationsRejectsAppIdentityForOtherApp(t *testing.T) {
+	identityID := uuid.New()
+	ctx := metadata.NewIncomingContext(context.Background(), metadata.Pairs(identityMetadata, identityID.String()))
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	otherAppID := uuid.New()
+	store.getByIdentityFn = func(_ context.Context, _ uuid.UUID) (storepkg.App, error) {
+		return storepkg.App{Meta: storepkg.EntityMeta{ID: appID}, IdentityID: identityID}, nil
+	}
+	listCalled := false
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, _ storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		listCalled = true
+		return []storepkg.Installation{}, "", nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	_, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{AppId: otherAppID.String()})
+	if status.Code(err) != codes.PermissionDenied {
+		t.Fatalf("expected permission denied, got %v", status.Code(err))
+	}
+	if listCalled {
+		t.Fatalf("did not expect list installations call")
+	}
+}
+
+func TestListInstallationsFiltersByMembershipWithAppID(t *testing.T) {
+	ctx, callerID := newAdminContext()
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	store := &fakeStore{}
+
+	appID := uuid.New()
+	allowedOrg := uuid.New()
+	blockedOrg := uuid.New()
+	now := time.Now()
+	store.getByIdentityFn = func(_ context.Context, _ uuid.UUID) (storepkg.App, error) {
+		return storepkg.App{}, storepkg.NotFound("app")
+	}
+	store.listInstallationsFn = func(_ context.Context, _ int, _ string, filter storepkg.ListInstallationsFilter) ([]storepkg.Installation, string, error) {
+		if filter.AppID == nil || *filter.AppID != appID {
+			return nil, "", errors.New("expected app filter")
+		}
+		return []storepkg.Installation{
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: now, UpdatedAt: now},
+				AppID:          appID,
+				OrganizationID: allowedOrg,
+				Slug:           "allowed",
+			},
+			{
+				Meta:           storepkg.EntityMeta{ID: uuid.New(), CreatedAt: now, UpdatedAt: now},
+				AppID:          appID,
+				OrganizationID: blockedOrg,
+				Slug:           "blocked",
+			},
+		}, "", nil
+	}
+	authorizationClient.checkFn = func(_ context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error) {
+		if req.GetTupleKey().GetObject() == fmt.Sprintf("organization:%s", allowedOrg) {
+			return &authorizationv1.CheckResponse{Allowed: true}, nil
+		}
+		return &authorizationv1.CheckResponse{Allowed: false}, nil
+	}
+
+	srv := New(store, identityClient, authorizationClient, zitiClient)
+	resp, err := srv.ListInstallations(ctx, &appsv1.ListInstallationsRequest{AppId: appID.String()})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(resp.GetInstallations()) != 1 {
+		t.Fatalf("expected one authorized installation")
+	}
+	if resp.GetInstallations()[0].GetOrganizationId() != allowedOrg.String() {
+		t.Fatalf("expected installation for org %s", allowedOrg)
+	}
+	if len(authorizationClient.checkRequests) != 2 {
+		t.Fatalf("expected membership checks for both orgs")
+	}
+	for _, check := range authorizationClient.checkRequests {
+		if check.GetTupleKey().GetRelation() != "member" {
+			t.Fatalf("expected member relation")
+		}
+		if check.GetTupleKey().GetUser() != fmt.Sprintf("identity:%s", callerID) {
+			t.Fatalf("expected user to be %s", callerID)
+		}
+	}
+}
+
 func TestListInstallationsFiltersByMembership(t *testing.T) {
 	ctx, callerID := newAdminContext()
 	identityClient := &fakeIdentityClient{}


### PR DESCRIPTION
## Summary
- allow app identities to list installations for matching app_id without org membership checks
- preserve member-based filtering for user identities when app_id is provided
- add server tests for app identity and user list behaviors

## Testing
- go vet ./...
- go test ./...

Closes #14