### PR TITLE
Align CI with centralized E2E workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,30 @@
+name: E2E
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Provision cluster
+        uses: agynio/bootstrap/.github/actions/provision@main
+
+      - name: Setup DevSpace
+        uses: agynio/e2e/.github/actions/setup-devspace@main
+
+      - name: Deploy apps from source
+        run: devspace dev
+
+      - name: Run E2E tests
+        uses: agynio/e2e/.github/actions/run-tests@main
+        with:
+          service: apps

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -2,7 +2,6 @@ version: v2beta1
 
 vars:
   APPS_NAMESPACE: platform
-  E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
 
 functions:
   disable_argocd_sync: |-
@@ -40,7 +39,7 @@ functions:
               emptyDir: {}
           containers:
             - name: apps
-              image: ghcr.io/agynio/devcontainer-go:1 # keep in sync with E2E_IMAGE
+              image: ghcr.io/agynio/devcontainer-go:1 # dev container for source deploy
               workingDir: /opt/app/data
               command:
                 - sh
@@ -81,26 +80,6 @@ functions:
     EOF
     )"
 
-deployments:
-  e2e-runner:
-    namespace: ${APPS_NAMESPACE}
-    helm:
-      chart:
-        name: component-chart
-        repo: https://charts.devspace.sh
-      values:
-        containers:
-          - image: ${E2E_IMAGE}
-            env:
-              - name: APPS_ADDR
-                value: "apps:50051"
-        labels:
-          app.kubernetes.io/name: apps-e2e
-
-commands:
-  test:e2e: |-
-    devspace run-pipeline test:e2e $@
-
 pipelines:
   dev:
     flags:
@@ -130,20 +109,6 @@ pipelines:
         echo "Dev environment ready. Stopping dev session."
         stop_dev apps
       fi
-
-  test:e2e:
-    run: |-
-      create_deployments e2e-runner
-      start_dev e2e-runner &
-      sleep 5
-      exec_container \
-        --label-selector "app.kubernetes.io/name=apps-e2e" \
-        -n ${APPS_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && buf generate buf.build/agynio/api --path agynio/api/apps/v1 --path agynio/api/authorization/v1 --path agynio/api/identity/v1 --path agynio/api/ziti_management/v1 && go test -v -count=1 -tags e2e ./test/e2e/'
-      EXIT_CODE=$?
-      stop_dev e2e-runner
-      purge_deployments e2e-runner
-      exit $EXIT_CODE
 
 hooks:
   - name: restore-argocd-auto-sync
@@ -185,17 +150,3 @@ dev:
           lastLines: 200
     ports:
       - port: "50051"
-
-  e2e-runner:
-    namespace: ${APPS_NAMESPACE}
-    labelSelector:
-      app.kubernetes.io/name: apps-e2e
-    command: ["sleep", "infinity"]
-    workingDir: /opt/app/data
-    sync:
-      - path: ./:/opt/app/data
-        excludePaths:
-          - .git/
-          - .devspace/
-          - /.gen/
-          - /tmp/

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -327,6 +327,10 @@ func (f *fakeIdentityClient) ResolveNickname(ctx context.Context, _ *identityv1.
 	return nil, status.Error(codes.Unimplemented, "not implemented")
 }
 
+func (f *fakeIdentityClient) BatchGetNicknames(ctx context.Context, _ *identityv1.BatchGetNicknamesRequest, _ ...grpc.CallOption) (*identityv1.BatchGetNicknamesResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "not implemented")
+}
+
 type fakeAuthorizationClient struct {
 	checkFn       func(ctx context.Context, req *authorizationv1.CheckRequest) (*authorizationv1.CheckResponse, error)
 	writeFn       func(ctx context.Context, req *authorizationv1.WriteRequest) (*authorizationv1.WriteResponse, error)


### PR DESCRIPTION
## Summary
- Adds an E2E workflow that composes `agynio/bootstrap/.github/actions/provision@main`, a service-owned `devspace dev` deploy-from-source step, and `agynio/e2e/.github/actions/run-tests@main`.
- Removes repo-local E2E runner deployment/pipeline from `devspace.yaml` so E2E execution stays centralized in `agynio/e2e`.
- Adds read-only workflow permissions to CI/E2E.
- Updates the test fake identity client for the current generated Identity API surface.
- Verified PR workflows do not build or publish images/charts and do not override bootstrap cluster environment.

Closes #17

## Test & Lint Summary
- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml` — passed with no errors.
- `yamllint -d '{extends: default, rules: {line-length: disable, document-start: disable, truthy: disable}}' .github/workflows/ci.yml .github/workflows/e2e.yml .github/workflows/release.yml devspace.yaml` — passed with no errors.
- `buf generate --template buf.gen.yaml` — passed.
- `gofmt -w $(find cmd internal -name '*.go' -print)` — passed with no committed formatting-only changes.
- `go vet ./...` — passed with no errors.
- `go test ./...` — 2 packages passed, 0 failed, 0 skipped.
- `go build ./...` — passed.
- `devspace print --debug` — passed.