### PR TITLE
fix(e2e): patch apps deployment

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -26,7 +26,7 @@ functions:
     fi
   patch_deployment: |-
     echo "Patching apps deployment for DevSpace..."
-    kubectl patch deployment apps-apps -n ${APPS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
+    kubectl patch deployment apps -n ${APPS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
     spec:
       template:
         spec:


### PR DESCRIPTION
## Summary
- Fixes #19
- Updates DevSpace source deploy patching to target the actual Helm deployment name: `apps`.
- Verified the provisioned bootstrap stack sets `fullnameOverride = "apps"`, so the service-base chart renders `Deployment/apps` rather than `Deployment/apps-apps`.

## Test & Lint Summary
- `buf generate --template buf.gen.yaml`: passed
- `go vet ./...`: passed with no errors
- `go test ./...`: 2 packages passed, 0 failed, 0 skipped; 4 packages had no test files
- `go build ./...`: passed
- `helm dependency build charts/apps`: passed
- `helm lint charts/apps`: 1 chart linted, 0 failed; no lint errors
- `helm template apps charts/apps --set fullnameOverride=apps | awk '/kind: Deployment/{seen=1} seen && /name: apps/{print; exit}'`: confirmed rendered deployment name `apps`