### PR TITLE
fix(chart): stabilize platform defaults

### DIFF
--- a/charts/apps/values.yaml
+++ b/charts/apps/values.yaml
@@ -1,5 +1,5 @@
 nameOverride: ""
-fullnameOverride: ""
+fullnameOverride: "apps"
 
 global:
   imageRegistry: ""
@@ -73,7 +73,10 @@ env:
   - name: GRPC_ADDRESS
     value: ":50051"
   - name: DATABASE_URL
-    value: ""
+    valueFrom:
+      secretKeyRef:
+        name: agyn-platform-database-urls
+        key: apps
   - name: IDENTITY_GRPC_TARGET
     value: "identity:50051"
   - name: AUTHORIZATION_GRPC_TARGET


### PR DESCRIPTION
## Summary
- Stabilizes chart defaults for agyn-platform production deployment.
- Moves stable fullname, database Secret, sibling service, and runtime defaults into the service chart.
- Keeps generated Chart.lock, vendored chart archives, and packaged outputs out of the commit.

Refs #4

## Validation
- `helm dependency build charts/<chart>`
- `helm lint charts/<chart>`
- `helm template test charts/<chart>`

Results: 1 chart linted, 0 failed; template render succeeded.
