### PR TITLE
fix: add inbox:write to the permission vocabulary

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -186,5 +186,3 @@ dev:
         logs:
           enabled: true
           lastLines: 200
-    ports:
-      - port: "50051"

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -31,6 +31,10 @@ var permissionToRelation = map[string]string{
 	"thread:create":   "thread_create",
 	"thread:write":    "thread_write",
 	"participant:add": "participant_add",
+	// The authorization model grants an agent instance's can_write_inbox from
+	// its organization's inbox_write; without this entry no app can be granted
+	// that relation, so direct inbox writes are unreachable.
+	"inbox:write": "inbox_write",
 }
 
 type AppStore interface {

--- a/internal/server/validation_test.go
+++ b/internal/server/validation_test.go
@@ -14,6 +14,13 @@ func TestValidatePermissions(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			// Without it in the vocabulary the inbox_write relation the
+			// authorization model defines can never be granted to an app.
+			name:        "inbox write",
+			permissions: []string{"inbox:write"},
+			wantErr:     false,
+		},
+		{
 			name:        "unknown",
 			permissions: []string{"unknown"},
 			wantErr:     true,


### PR DESCRIPTION
The authorization model defines `inbox_write` on organization and resolves an agent instance's `can_write_inbox` from it, but `permissionToRelation` never listed `inbox:write`. `validatePermissions` rejects anything missing from that map, so no app could ever be granted the relation and direct inbox writes were unreachable.