### PR TITLE
ci(e2e): provision the platform VM instead of bootstrap

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Provision cluster
-        uses: agynio/bootstrap/.github/actions/provision@main
+        uses: agynio/e2e/.github/actions/provision-vm@main
 
       - name: Setup DevSpace
         uses: agynio/e2e/.github/actions/setup-devspace@main


### PR DESCRIPTION
Swaps the cluster provisioning step from `agynio/bootstrap/.github/actions/provision` to `agynio/e2e/.github/actions/provision-vm`, which boots the prebuilt platform VM and exports the same environment `run-tests` already reads.

Part of retiring `agynio/bootstrap`.