### PR TITLE
fix: create an app with no permissions

### DIFF
--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -115,6 +115,13 @@ func New(pool *pgxpool.Pool) *Store {
 	return &Store{pool: pool}
 }
 
+func nonNilStrings(values []string) []string {
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
 func scanApp(row pgx.Row) (App, error) {
 	var app App
 	if err := row.Scan(
@@ -175,7 +182,11 @@ func (s *Store) CreateApp(ctx context.Context, input CreateAppInput) (App, error
 		input.ZitiServiceID,
 		input.OrganizationID,
 		input.Visibility,
-		input.Permissions,
+		// A nil slice binds as SQL NULL, and the column is NOT NULL. Its
+		// DEFAULT cannot stand in either: naming the column in the INSERT is
+		// what disables the default. An app with no permissions is ordinary,
+		// so it gets an empty array.
+		nonNilStrings(input.Permissions),
 	)
 	app, err := scanApp(row)
 	if err != nil {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1,0 +1,15 @@
+package store
+
+import "testing"
+
+// A nil slice binds as SQL NULL and the permissions column is NOT NULL, so an
+// app created without permissions failed the insert outright.
+func TestNonNilStrings(t *testing.T) {
+	if got := nonNilStrings(nil); got == nil || len(got) != 0 {
+		t.Fatalf("expected an empty non-nil slice, got %#v", got)
+	}
+	values := []string{"thread:create"}
+	if got := nonNilStrings(values); len(got) != 1 || got[0] != values[0] {
+		t.Fatalf("expected the values to pass through, got %#v", got)
+	}
+}


### PR DESCRIPTION
A nil slice binds as SQL NULL and `permissions` is `NOT NULL`. The column's `DEFAULT '{}'` cannot stand in either — naming a column in the INSERT is exactly what disables its default — so creating an app that asked for no permissions failed outright:

```
CreateApp reminders failed: null value in column "permissions" of relation "apps"
violates not-null constraint (SQLSTATE 23502)
```

The VM install hits this provisioning its `reminders` app; it retries for twenty minutes and then fails the image build.