### PR TITLE
fix: list an app's groups as the app

### DIFF
--- a/internal/server/group_sync.go
+++ b/internal/server/group_sync.go
@@ -9,6 +9,7 @@ import (
 	zitimanagementv1 "github.com/agynio/apps/.gen/go/agynio/api/ziti_management/v1"
 	"github.com/agynio/apps/internal/store"
 	"github.com/google/uuid"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -45,6 +46,13 @@ func (s *Server) appGroupRoleAttributes(ctx context.Context, app store.App) ([]s
 }
 
 func (s *Server) listAppGroups(ctx context.Context, app store.App) ([]*groupsv1.Group, error) {
+	// As the app, not as whoever happens to be on the inbound context. Groups
+	// lets a member list its own memberships and otherwise demands organization
+	// membership -- and the two callers here have no user identity to forward:
+	// EnrollApp authenticates with the app's service token, and the membership
+	// event handler runs off NATS with no caller at all. Both used to arrive
+	// with nothing and were refused outright.
+	ctx = metadata.AppendToOutgoingContext(ctx, identityMetadata, app.IdentityID.String())
 	groups := []*groupsv1.Group{}
 	pageToken := ""
 	for {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2310,6 +2310,42 @@ func TestListInstallationAuditLogEntriesRejectsNonMember(t *testing.T) {
 	}
 }
 
+// Groups lets a member list its own memberships and otherwise demands
+// organization membership. EnrollApp authenticates with a service token and
+// carries no user identity, so unless the app names itself the call is refused
+// and no app can ever enroll.
+func TestEnrollAppListsGroupsAsTheApp(t *testing.T) {
+	identityClient := &fakeIdentityClient{}
+	authorizationClient := &fakeAuthorizationClient{}
+	zitiClient := &fakeZitiManagementClient{}
+	fakeStore := &fakeStore{}
+
+	identityID := uuid.New()
+	organizationID := uuid.New()
+	fakeStore.updateZitiIdentityFn = func(context.Context, uuid.UUID, string, string) error { return nil }
+	fakeStore.getByServiceTokenFn = func(_ context.Context, _ string) (storepkg.App, error) {
+		return storepkg.App{
+			Meta:           storepkg.EntityMeta{ID: uuid.New()},
+			Slug:           "demo",
+			IdentityID:     identityID,
+			OrganizationID: organizationID,
+			ZitiServiceID:  "service-id",
+		}, nil
+	}
+	fakeGroups := &fakeGroupsClient{groupsByOrg: map[string][]*groupsv1.Group{}}
+
+	srv := NewWithGroups(fakeStore, identityClient, authorizationClient, zitiClient, fakeGroups)
+	if _, err := srv.EnrollApp(context.Background(), &appsv1.EnrollAppRequest{ServiceToken: "raw-token"}); err != nil {
+		t.Fatalf("EnrollApp failed: %v", err)
+	}
+	if len(fakeGroups.callerIdentities) != 1 {
+		t.Fatalf("expected one groups lookup, got %d", len(fakeGroups.callerIdentities))
+	}
+	if fakeGroups.callerIdentities[0] != identityID.String() {
+		t.Fatalf("expected the groups lookup to name the app identity %s, got %q", identityID, fakeGroups.callerIdentities[0])
+	}
+}
+
 func TestEnrollAppIncludesGroupAttrs(t *testing.T) {
 	identityClient := &fakeIdentityClient{}
 	authorizationClient := &fakeAuthorizationClient{}
@@ -2595,10 +2631,18 @@ type fakeGroupsClient struct {
 	groupsByOrg      map[string][]*groupsv1.Group
 	pagedGroupsByOrg map[string][][]*groupsv1.Group
 	requests         []*groupsv1.ListMemberGroupsRequest
+	callerIdentities []string
 }
 
-func (c *fakeGroupsClient) ListMemberGroups(_ context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
+func (c *fakeGroupsClient) ListMemberGroups(ctx context.Context, request *groupsv1.ListMemberGroupsRequest, _ ...grpc.CallOption) (*groupsv1.ListMemberGroupsResponse, error) {
 	c.requests = append(c.requests, request)
+	caller := ""
+	if md, ok := metadata.FromOutgoingContext(ctx); ok {
+		if values := md.Get(identityMetadata); len(values) == 1 {
+			caller = values[0]
+		}
+	}
+	c.callerIdentities = append(c.callerIdentities, caller)
 	if c.pagedGroupsByOrg != nil {
 		pages := c.pagedGroupsByOrg[request.GetOrganizationId()]
 		pageIndex := 0


### PR DESCRIPTION
No first-party app can enroll — this is what the VM image build now dies on, for both `reminders` and `telegram-connector`:

```
enroll app: enroll app: internal: list app group memberships: list member groups:
rpc error: code = Unauthenticated desc = missing identity id
```

`groups.ListMemberGroups` allows a caller that **is** the member being listed, and otherwise requires organization membership. Neither caller of `listAppGroups` has a user identity to forward: `EnrollApp` authenticates with the app's service token, and `HandleGroupMembershipEvent` runs off NATS with no caller at all. The call went out bare and was refused.

The app is the member being listed, so it now names itself. That is the path groups already permits — no authorization rule changes.

A test pins it: it fails with `got ""` before the fix.