### PR TITLE
fix(devspace): find the pod by name, not by release

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -162,7 +162,6 @@ dev:
     namespace: ${APPS_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: apps
-      app.kubernetes.io/instance: apps
     containers:
       apps:
         container: apps


### PR DESCRIPTION
Deploying this service from source into the platform VM hangs:

```
DevSpace still couldn't find any Pods that match the selector
```

The `dev` selector paired `app.kubernetes.io/name` with `app.kubernetes.io/instance=<service>`. That held when every service was its own Helm release. The **agyn-platform umbrella** makes the instance label its own release name, so the selector matches nothing — verified against a running VM, where the pod carries `app.kubernetes.io/instance: agyn-platform`.

The pod starts and spins waiting for a binary the sync never delivers, and the deploy times out having already patched a Deployment it cannot reach.

The `name` label alone is unique in the namespace and is correct under both layouts. Same fix as the E2E workflow’s own selectors.