### PR TITLE
chore: remove the ArgoCD sync dance

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -162,7 +162,6 @@ dev:
     namespace: ${APPS_NAMESPACE}
     labelSelector:
       app.kubernetes.io/name: apps
-      app.kubernetes.io/instance: apps
     containers:
       apps:
         container: apps

--- a/devspace.yaml
+++ b/devspace.yaml
@@ -4,26 +4,6 @@ vars:
   APPS_NAMESPACE: platform
 
 functions:
-  disable_argocd_sync: |-
-    if kubectl get application apps -n argocd >/dev/null 2>&1; then
-      echo "Disabling ArgoCD auto-sync for apps..."
-      kubectl patch application apps -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":null}}}'
-      echo "ArgoCD auto-sync disabled."
-    else
-      echo "WARNING: ArgoCD Application 'apps' not found in argocd namespace."
-    fi
-  restore_argocd_sync: &restore_argocd_sync |-
-    if kubectl get application apps -n argocd >/dev/null 2>&1; then
-      echo "Re-enabling ArgoCD auto-sync for apps..."
-      kubectl patch application apps -n argocd \
-        --type merge \
-        -p '{"spec":{"syncPolicy":{"automated":{"prune":true,"selfHeal":true}}}}'
-      echo "ArgoCD auto-sync restored."
-    else
-      echo "WARNING: ArgoCD Application 'apps' not found in argocd namespace."
-    fi
   patch_deployment: |-
     echo "Patching apps deployment for DevSpace..."
     kubectl patch deployment apps -n ${APPS_NAMESPACE} --type strategic --patch "$(cat <<'EOF'
@@ -97,7 +77,6 @@ pipelines:
         short: w
         description: "Keep DevSpace running and stream logs"
     run: |-
-      disable_argocd_sync
       patch_deployment
       if [ "$(get_flag "watch")" == "true" ]; then
         start_dev --disable-pod-replace apps
@@ -149,13 +128,6 @@ pipelines:
       fi
 
 hooks:
-  - name: restore-argocd-auto-sync
-    events:
-      - after:dev:apps
-    command: bash
-    args:
-      - -c
-      - *restore_argocd_sync
 
 dev:
   apps:


### PR DESCRIPTION
ArgoCD went away with bootstrap. Disabling its auto-sync before a source deploy and restoring it after has had nothing to disable or restore since the platform moved to the VM — every run printed `WARNING: ArgoCD Application not found in argocd namespace` and carried on.

Removes the `disable_argocd_sync` / `restore_argocd_sync` functions, their call sites, the `restore-argocd` pipeline and the `after:dev` hook.

Part of removing the E2E workflow’s build-time source patches: three of them existed only to inject a "skip the ArgoCD restore in CI" branch into this file.